### PR TITLE
cleanup for first release

### DIFF
--- a/FoundationalBits.Spec/Messaging/Specs.cs
+++ b/FoundationalBits.Spec/Messaging/Specs.cs
@@ -14,7 +14,7 @@ namespace FoundationalBits.Spec.Messaging
         [Test]
         public static async Task to_an_interested_subscriber()
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             var monitor = new HandleMonitor<object>();
             cut.Subscribe(monitor);
             await cut.Publish(new object());
@@ -27,7 +27,7 @@ namespace FoundationalBits.Spec.Messaging
         [TestCaseSource(nameof(ErrorSubscribers))]
         public static void is_propagated_to_sender(object subscriber)
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             cut.Subscribe(subscriber);
 
             Assert.CatchAsync<DispatchFailed>(() => cut.Publish(new object()))
@@ -38,7 +38,7 @@ namespace FoundationalBits.Spec.Messaging
         public static void does_not_prevent_dispatch_to_other_subscribers(
             object subscriber)
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             cut.Subscribe(subscriber);
             var monitor = new HandleMonitor<object>();
             cut.Subscribe(monitor);
@@ -64,7 +64,7 @@ namespace FoundationalBits.Spec.Messaging
                 new ThrowingHandler<object>(),
                 new AsyncThrowingHandler<object>()
             };
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             errorSubscribers.ForEach(s => cut.Subscribe(s));
             Assert.CatchAsync<DispatchFailed>(() => cut.Publish(new object()))
                 .Should().Match<DispatchFailed>(e => HasMultipleDispatchErrors(e));
@@ -81,7 +81,7 @@ namespace FoundationalBits.Spec.Messaging
         [Test]
         public static async Task to_garbage_collected_subscribers()
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             var monitor = new HandleMonitor<object>();
             await cut.SubscribeWeak(new TestHandler<object>(monitor)).WaitForCollection();
             await cut.Publish(new object());
@@ -91,7 +91,7 @@ namespace FoundationalBits.Spec.Messaging
         [Test]
         public static async Task to_unsubscribed_subscribers()
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             var monitor = new HandleMonitor<object>();
             cut.SubscribeUnsubscribe(new TestHandler<object>(monitor));
             await cut.Publish(new object());
@@ -101,7 +101,7 @@ namespace FoundationalBits.Spec.Messaging
         [Test]
         public static async Task to_uninterested_subscribers()
         {
-            var cut = new AgentBasedMessageBus();
+            var cut = MessageBus.Create();
             var monitor = new HandleMonitor<int>();
             var subscriber = new TestHandler<int>(monitor);
             cut.Subscribe(subscriber);

--- a/FoundationalBits.sln.DotSettings
+++ b/FoundationalBits.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=bridgefield/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/FoundationalBits/Agent.cs
+++ b/FoundationalBits/Agent.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Threading.Tasks;
+using bridgefield.FoundationalBits.Agents;
+
+namespace bridgefield.FoundationalBits
+{
+    public static class Agent
+    {
+        public static IAgent<TCommand, TReply> Start<TState, TCommand, TReply>(
+            TState initialState,
+            Func<TState, TCommand, Task<(TState newState, TReply reply)>> update)
+            => new StatefulAgent<TState, TCommand, TReply>(initialState, update);
+
+        public static IAgent<TCommand, TReply> Start<TCommand, TReply>(
+            Func<TCommand, Task<TReply>> update)
+            => new StatelessAgent<TCommand, TReply>(update);
+    }
+}

--- a/FoundationalBits/Agents/StatelessAgent.cs
+++ b/FoundationalBits/Agents/StatelessAgent.cs
@@ -4,30 +4,22 @@ using System.Threading.Tasks.Dataflow;
 
 namespace bridgefield.FoundationalBits.Agents
 {
-    public sealed class StatelessAgent<TCommand, TReply> : IAgent<TCommand, TReply>
+    internal sealed class StatelessAgent<TCommand, TReply> : IAgent<TCommand, TReply>
     {
-        private readonly ActionBlock<(TCommand command, TaskCompletionSource<TReply> task)> actions;
+        private readonly ActionBlock<(TCommand command, TaskCompletionSource<TReply> task)> actionBlock;
 
         public StatelessAgent(Func<TCommand, Task<TReply>> processor) =>
-            actions = new ActionBlock<(TCommand command, TaskCompletionSource<TReply> task)>(
+            actionBlock = new(
                 data => processor(data.command)
-                    .ContinueWith(task =>
-                    {
-                        if (task.IsFaulted)
-                        {
-                            data.task.SetException(task.Exception);
-                        }
-                        else
-                        {
-                            data.task.SetResult(task.Result);
-                        }
-                    })
+                    .HandleResult(
+                        data.task.SetResult,
+                        data.task.SetException)
             );
 
         public Task<TReply> Tell(TCommand command)
         {
             var completionSource = new TaskCompletionSource<TReply>(TaskCreationOptions.RunContinuationsAsynchronously);
-            actions.Post((command, completionSource));
+            actionBlock.Post((command, completionSource));
             return completionSource.Task;
         }
     }

--- a/FoundationalBits/Agents/Tasks.cs
+++ b/FoundationalBits/Agents/Tasks.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Threading.Tasks;
+
+namespace bridgefield.FoundationalBits.Agents
+{
+    internal static class Tasks
+    {
+        public static Task HandleResult<T>(
+            this Task<T> task,
+            Action<T> onSuccess,
+            Action<Exception> onError) =>
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                {
+                    onError(task.Exception);
+                }
+                else
+                {
+                    onSuccess(task.Result);
+                }
+            });
+    }
+}

--- a/FoundationalBits/FoundationalBits.csproj
+++ b/FoundationalBits/FoundationalBits.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="bridgefield.MonadicBits" Version="0.4.0"/>
-        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0"/>
+        <PackageReference Include="bridgefield.MonadicBits" Version="0.4.0" />
+        <PackageReference Include="System.Threading.Tasks.Dataflow" Version="6.0.0" />
     </ItemGroup>
 </Project>

--- a/FoundationalBits/IAgent.cs
+++ b/FoundationalBits/IAgent.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Threading.Tasks;
-using bridgefield.FoundationalBits.Agents;
 
 namespace bridgefield.FoundationalBits
 {
@@ -8,13 +6,5 @@ namespace bridgefield.FoundationalBits
     public interface IAgent<TCommand, TReply>
     {
         Task<TReply> Tell(TCommand command);
-
-        static IAgent<TCommand, TReply> Start<TState>(
-            TState initialState,
-            Func<TState, TCommand, Task<(TState newState, TReply reply)>> update)
-            => new StatefulAgent<TState, TCommand, TReply>(initialState, update);
-
-        static IAgent<TCommand, TReply> Start(Func<TCommand, Task<TReply>> update)
-            => new StatelessAgent<TCommand, TReply>(update);
     }
 }

--- a/FoundationalBits/MessageBus.cs
+++ b/FoundationalBits/MessageBus.cs
@@ -1,0 +1,9 @@
+using bridgefield.FoundationalBits.Messaging;
+
+namespace bridgefield.FoundationalBits
+{
+    public static class MessageBus
+    {
+        public static IMessageBus Create() => new AgentBasedMessageBus();
+    }
+}

--- a/FoundationalBits/Messaging/AgentBasedMessageBus.cs
+++ b/FoundationalBits/Messaging/AgentBasedMessageBus.cs
@@ -5,16 +5,17 @@ using System.Threading.Tasks;
 
 namespace bridgefield.FoundationalBits.Messaging
 {
-    public sealed class AgentBasedMessageBus : IMessageBus
+    internal sealed class AgentBasedMessageBus : IMessageBus
     {
         private sealed record State(ImmutableList<Subscription> Subscriptions);
 
         private readonly IAgent<SubscriptionCommand, IEnumerable<Subscription>> agent;
 
         public AgentBasedMessageBus() =>
-            agent = IAgent<SubscriptionCommand, IEnumerable<Subscription>>.Start(
+            agent = Agent.Start<State, SubscriptionCommand, IEnumerable<Subscription>>(
                 new State(ImmutableList<Subscription>.Create()),
-                (state, command) => command.Execute(state));
+                (state, command) => command.Execute(state)
+            );
 
         public void Subscribe(object subscriber) =>
             Subscribe(subscriber, SubscriptionLifecycle.GarbageCollected);

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Useful bits for foundational groundwork in C# applications.
   
   ...
   
-  var messageBus = new AgentBasedMessageBus()
+  var messageBus = MessageBus.Create()
   messageBus.Subscribe(
     new Receiver(),
     SubscriptionLifecycle.ExplicitUnsubscribe);
@@ -35,7 +35,7 @@ Useful bits for foundational groundwork in C# applications.
     Decrement,
     Current,
   }
-  var counter = IAgent<CounterCommand,int>.Start<int>(
+  var counter = Agent.Start<CounterCommand,int,int>(
     0,
     (current,command) => command switch{
       CounterCommand.Increment => (current+1, current+1),


### PR DESCRIPTION
- move component instantiation into factory methods to prevent
problems with static interface methods
- mark agent and message bus implementations as internal
- use common task result handling
- update usage in readme